### PR TITLE
Provide common configuration for app projects

### DIFF
--- a/bin/nrfconnect-scripts.js
+++ b/bin/nrfconnect-scripts.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+'use strict';
+
+const spawnSync = require('child_process').spawnSync;
+
+const args = process.argv.slice(2);
+const script = args[0];
+const extraArgs = args.slice(1);
+
+const SCRIPTS = {
+    'build-watch': [require.resolve('../scripts/build.js'), '--watch'],
+    'build-dev': [require.resolve('../scripts/build.js'), '--dev'],
+    'build-prod': [require.resolve('../scripts/build.js'), '--prod'],
+    'lint': [require.resolve('../scripts/lint.js')].concat(extraArgs),
+    'test': [require.resolve('../scripts/test.js')].concat(extraArgs),
+};
+
+const result = spawnSync('node', SCRIPTS[script], { stdio: 'inherit' });
+process.exit(result.status);

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -1,0 +1,60 @@
+{
+    "extends": [
+        "eslint:recommended",
+        "airbnb"
+    ],
+    "rules": {
+        "indent": [
+            "error",
+            4,
+            {
+                "SwitchCase": 1
+            }
+        ],
+        "react/jsx-indent": [
+            "error",
+            4
+        ],
+        "react/jsx-indent-props": [
+            "error",
+            4
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "linebreak-style": "off",
+        "arrow-parens": [
+            "error",
+            "as-needed"
+        ],
+        "arrow-body-style": [
+            "error",
+            "as-needed"
+        ],
+        "strict": "off",
+        "no-console": "off",
+        "valid-jsdoc": 2,
+        "import/no-extraneous-dependencies": 0,
+        "import/no-unresolved": [
+            "error",
+            {
+                "ignore": [ "nrfconnect/.*", "pc-ble-driver-js", "pc-nrfjprog-js", "serialport", "electron" ]
+            }
+        ],
+        "import/extensions": ["off"]
+    },
+    "no-undef": 1,
+    "no-unused-vars": 1,
+    "plugins": [
+        "react",
+        "import"
+    ],
+    "env": {
+        "es6": true,
+        "browser": true,
+        "node": true,
+        "jasmine": true,
+        "jest": true
+    }
+}

--- a/config/jest.config.json
+++ b/config/jest.config.json
@@ -1,0 +1,11 @@
+{
+  "rootDir": "../../../",
+  "moduleNameMapper": {
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/fileMock.js",
+    "\\.(css|less)$": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/styleMock.js",
+    "nrfconnect/core": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/coreMock.js",
+    "pc-ble-driver-js": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/bleDriverMock.js",
+    "pc-nrfjprog-js": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/nrfjprogMock.js",
+    "serialport": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/serialportMock.js"
+  }
+}

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,0 +1,89 @@
+const webpack = require('webpack');
+const path = require('path');
+const fs = require('fs');
+const dependencies = require('../../../package.json').dependencies;
+
+const appDirectory = fs.realpathSync(process.cwd());
+const nodeEnv = process.env.NODE_ENV || 'development';
+const isProd = nodeEnv === 'production';
+
+function createExternals() {
+    // Libs provided by nRF Connect at runtime
+    const coreLibs = [
+        'react',
+        'react-dom',
+        'react-redux',
+        'pc-ble-driver-js',
+        'pc-nrfjprog-js',
+        'serialport',
+        'electron',
+        'nrfconnect/core',
+    ];
+
+    // Libs provided by the app at runtime
+    const appLibs = Object.keys(dependencies);
+
+    return coreLibs.concat(appLibs).reduce((prev, lib) => (
+        Object.assign(prev, { [lib]: lib })
+    ), {});
+}
+
+let eslintConfig;
+try {
+    eslintConfig = require.resolve('../../../.eslintrc');
+} catch (err) {
+    eslintConfig = require.resolve('./eslintrc.json');
+}
+
+module.exports = {
+    devtool: isProd ? 'hidden-source-map' : 'inline-cheap-source-map',
+    entry: './index.jsx',
+    output: {
+        path: path.join(appDirectory, 'dist'),
+        publicPath: './dist/',
+        filename: 'bundle.js',
+        libraryTarget: 'umd',
+    },
+    module: {
+        rules: [{
+            test: /\.(js|jsx)$/,
+            use: [{
+                loader: require.resolve('babel-loader'),
+                options: {
+                    cacheDirectory: true,
+                }
+            }, {
+                loader: require.resolve('eslint-loader'),
+                options: {
+                    configFile: eslintConfig,
+                }
+            }],
+            exclude: /node_modules/,
+        }, {
+            test: /\.json$/,
+            loader: require.resolve('json-loader'),
+        }, {
+            test: /\.less$/,
+            loaders: [
+                require.resolve('style-loader'),
+                require.resolve('css-loader'),
+                require.resolve('less-loader'),
+            ],
+        }, {
+            test: /\.(png|gif|ttf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
+            loader: require.resolve('file-loader'),
+        }],
+    },
+    resolve: {
+        extensions: ['.js', '.jsx'],
+    },
+    plugins: [
+        new webpack.DefinePlugin({
+            'process.env': {
+                NODE_ENV: JSON.stringify(nodeEnv),
+            },
+        }),
+    ],
+    target: 'electron-renderer',
+    externals: createExternals(),
+};

--- a/mocks/bleDriverMock.js
+++ b/mocks/bleDriverMock.js
@@ -1,0 +1,5 @@
+// Allows jest to test files that import pc-ble-driver-js.
+
+module.exports = {
+    AdapterFactory: { getInstance: () => {} },
+};

--- a/mocks/coreMock.js
+++ b/mocks/coreMock.js
@@ -1,0 +1,5 @@
+// Allows jest to test files that import nrfconnect/core.
+
+module.exports = {
+    logger: {},
+};

--- a/mocks/fileMock.js
+++ b/mocks/fileMock.js
@@ -1,0 +1,7 @@
+// Allows jest to test files that import images, fonts, etc. Jest cannot
+// parse things like this, so we have to mock them. This mock just returns
+// 'test-file-stub' for files that match the moduleNameMapper expression
+// in package.json.
+// Ref: https://facebook.github.io/jest/docs/tutorial-webpack.html
+
+module.exports = 'test-file-stub';

--- a/mocks/nrfjprogMock.js
+++ b/mocks/nrfjprogMock.js
@@ -1,0 +1,3 @@
+// Allows jest to test files that import pc-nrfjprog-js.
+
+module.exports = {};

--- a/mocks/serialportMock.js
+++ b/mocks/serialportMock.js
@@ -1,0 +1,3 @@
+// Allows jest to test files that import serialport.
+
+module.exports = {};

--- a/mocks/styleMock.js
+++ b/mocks/styleMock.js
@@ -1,0 +1,7 @@
+// Allows jest to test files that import less or css. Jest cannot
+// parse things like this so we have to mock them. This mock just returns
+// an empty object for files that match the moduleNameMapper expression
+// in package.json.
+// Ref: https://facebook.github.io/jest/docs/tutorial-webpack.html
+
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "author": "Nordic Semiconductor ASA",
   "license": "ISC",
+  "bin": {
+    "nrfconnect-scripts": "./bin/nrfconnect-scripts.js"
+  },
   "dependencies": {
     "babel-core": "6.24.1",
     "babel-loader": "7.0.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,91 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const webpack = require('webpack');
+
+function getConfig() {
+    let config;
+    try {
+        // Using custom webpack.config.js if it exists in project
+        config = require('../../../webpack.config.js');
+    } catch (err) {
+        config = require('../config/webpack.config.js');
+    }
+    return config;
+}
+
+function handleOutput(err, stats) {
+    if (err) {
+        console.error(err.stack || err);
+        if (err.details) {
+            console.error(err.details);
+        }
+        return;
+    }
+
+    const info = stats.toJson();
+
+    if (stats.hasErrors()) {
+        console.error(info.errors);
+    }
+
+    if (stats.hasWarnings()) {
+        console.warn(info.warnings)
+    }
+
+    console.log(stats.toString({
+        chunks: false,  // Makes the build much quieter
+        colors: true    // Shows colors in the console
+    }));
+}
+
+const args = process.argv.slice(2);
+if (args[0] === '--watch') {
+    webpack(getConfig()).watch({}, handleOutput);
+} else if (args[0] === '--dev') {
+    process.env.NODE_ENV = 'development';
+    webpack(getConfig()).run(handleOutput);
+} else if (args[0] === '--prod') {
+    process.env.NODE_ENV = 'production';
+    webpack(getConfig()).run(handleOutput);
+} else {
+    console.error('Please specify one of --watch, --dev, or --prod');
+    process.exit(1);
+}

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,0 +1,64 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const spawn = require('child_process').spawn;
+
+const eslint = path.join('node_modules', '.bin', 'eslint');
+
+let configFile;
+try {
+    // Using custom .eslintrc if it exists in project
+    configFile = require.resolve('../../../.eslintrc');
+} catch (err) {
+    configFile = require.resolve('../config/eslintrc.json');
+}
+
+const argv = process.argv.slice(2);
+argv.unshift('--config', configFile);
+
+const options = {
+    env: process.env,
+    shell: true,
+    stdio: 'inherit'
+};
+
+spawn(eslint, argv, options).on('exit', function (code) {
+    process.exit(code);
+});

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,53 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const jest = require('jest');
+
+let configFile;
+try {
+    // Using custom jest.config.json if it exists in project
+    configFile = require.resolve('../../../jest.config.json');
+} catch (err) {
+    configFile = require.resolve('../config/jest.config.json');
+}
+
+const argv = process.argv.slice(2);
+argv.unshift('--config', configFile);
+
+jest.run(argv);


### PR DESCRIPTION
Currently the webpack, jest, and eslint config is duplicated for every app project. If we want to change some common configuration, then we have to do it for every app project. We can improve this by adding common, reusable configuration to pc-nrfconnect-devdep.

When pc-nrfconnect-devdep is installed, it adds an nrfconnect-scripts.js file to node_modules/.bin. This way it can easily be invoked by the app's package.json scripts, like this:

```
  "scripts": {
    "dev": "nrfconnect-scripts build-watch",
    "webpack": "nrfconnect-scripts build-dev",
    "build": "nrfconnect-scripts build-prod",
    "lint": "nrfconnect-scripts lint lib",
    "test": "nrfconnect-scripts test",
    "test-watch": "nrfconnect-scripts test --watch",
  }
```

With this change the app projects no longer need webpack.config.js, a `jest` section in package.json, mocks directory, and .eslintrc. If an app wants to override the default config, it can add custom configuration files (webpack.config.js, jest.config.json, or .eslintrc) in the project root which will be used instead of the default ones.