### PR TITLE
Added function to webpack config to find entrypoint

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -35,9 +35,19 @@ try {
     eslintConfig = require.resolve('./eslintrc.json');
 }
 
+function findEntryPoint() {
+    const files = ['./src/index.jsx', './lib/index.jsx', './index.jsx'];
+    while (files.length) {
+        const file = files.shift();
+        if (fs.existsSync(file)) {
+            return file;
+        }
+    }
+}
+
 module.exports = {
     devtool: isProd ? 'hidden-source-map' : 'inline-cheap-source-map',
-    entry: './index.jsx',
+    entry: findEntryPoint(),
     output: {
         path: path.join(appDirectory, 'dist'),
         publicPath: './dist/',


### PR DESCRIPTION
Following our internal guidelines of code structure I introduced a function to find the entrypoint of an app modules in a backward compatible manner.