### PR TITLE
Add support for importing the usb module

### DIFF
--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -39,7 +39,7 @@
         "import/no-unresolved": [
             "error",
             {
-                "ignore": [ "nrfconnect/.*", "pc-ble-driver-js", "pc-nrfjprog-js", "serialport", "electron" ]
+                "ignore": [ "nrfconnect/.*", "pc-ble-driver-js", "pc-nrfjprog-js", "serialport", "usb", "electron" ]
             }
         ],
         "import/extensions": ["off"]

--- a/config/jest.config.json
+++ b/config/jest.config.json
@@ -6,6 +6,7 @@
     "nrfconnect/core": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/coreMock.js",
     "pc-ble-driver-js": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/bleDriverMock.js",
     "pc-nrfjprog-js": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/nrfjprogMock.js",
-    "serialport": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/serialportMock.js"
+    "serialport": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/serialportMock.js",
+    "usb": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/usbMock.js"
   }
 }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -16,6 +16,7 @@ function createExternals() {
         'pc-ble-driver-js',
         'pc-nrfjprog-js',
         'serialport',
+        'usb',
         'electron',
         'nrfconnect/core',
     ];

--- a/mocks/usbMock.js
+++ b/mocks/usbMock.js
@@ -1,0 +1,3 @@
+// Allows jest to test files that import usb.
+
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-devdep",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Common development dependencies for pc-nrfconnect-* packages.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Allows apps to import the usb module that is added by https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/157.