### PR TITLE
Add node_modules from devdep to NODE_PATH

### DIFF
--- a/bin/nrfconnect-scripts.js
+++ b/bin/nrfconnect-scripts.js
@@ -39,6 +39,7 @@
 
 'use strict';
 
+const path = require('path');
 const spawnSync = require('child_process').spawnSync;
 
 const args = process.argv.slice(2);
@@ -53,5 +54,9 @@ const SCRIPTS = {
     'test': [require.resolve('../scripts/test.js')].concat(extraArgs),
 };
 
-const result = spawnSync('node', SCRIPTS[script], { stdio: 'inherit' });
+const env = Object.assign({}, process.env, {
+    NODE_PATH: path.join(__dirname, '..', 'node_modules'),
+});
+
+const result = spawnSync('node', SCRIPTS[script], { stdio: 'inherit', env });
 process.exit(result.status);


### PR DESCRIPTION
When installing pc-nrfconnect-devdep in other projects, it does sometimes not flatten/dedupe the dependencies in devdep. The dependencies end up in "pc-nrfconnect-devdep/node_modules" instead of
the root node_modules directory. When running f.ex. webpack, it will then not find the dependencies, as it only looks in the root node_modules directory.

To fix this, we can add "pc-nrfconnect-devdep/node_modules" to the `NODE_PATH` environment variable when spawning processes from nrfconnect-scripts.js.

This will fix the issue with webpack and babel-loader, described in https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/155.