### PR TITLE
Lint both js and jsx when running nrfconnect-scripts lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-devdep",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Common development dependencies for pc-nrfconnect-* packages.",
   "repository": {
     "type": "git",

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -51,6 +51,7 @@ try {
 }
 
 const argv = process.argv.slice(2);
+argv.unshift('--ext', 'js,jsx');
 argv.unshift('--config', configFile);
 
 const options = {


### PR DESCRIPTION
The webpack config is set up to do linting of all js and jsx files that it parses. However, `nrfconnect-scripts lint` only performed linting on js files. Now linting jsx files with `nrfconnect-scripts lint` as well.

A fix for this was added in https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/174. Fixing it here instead, so that all nRF Connect projects will get it.