### PR TITLE
Add support for nrf-device-setup and nrf-usb

### DIFF
--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -39,7 +39,15 @@
         "import/no-unresolved": [
             "error",
             {
-                "ignore": [ "nrfconnect/.*", "pc-ble-driver-js", "pc-nrfjprog-js", "serialport", "usb", "electron" ]
+                "ignore": [
+                    "nrfconnect/.*",
+                    "pc-ble-driver-js",
+                    "pc-nrfjprog-js",
+                    "serialport",
+                    "nrf-usb",
+                    "nrf-device-setup",
+                    "electron"
+                ]
             }
         ],
         "import/extensions": ["off"]

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -13,12 +13,12 @@ function createExternals() {
         'react',
         'react-dom',
         'react-redux',
+        'electron',
+        'serialport',
         'pc-ble-driver-js',
         'pc-nrfjprog-js',
-        'serialport',
-        'usb',
         'nrf-usb',
-        'electron',
+        'nrf-device-setup',
         'nrfconnect/core',
     ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-devdep",
-  "version": "1.3.2",
+  "version": "1.3.4",
   "description": "Common development dependencies for pc-nrfconnect-* packages.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR is due to supporting of including nrf-usb and nrf-device-setup into pc-nrfconnect-core so that apps do not need to have duplicated dependencies.