### PR TITLE
Change file-loader to url-loader for resources, bump version

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -83,7 +83,7 @@ module.exports = {
             ],
         }, {
             test: /\.(png|gif|ttf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
-            loader: require.resolve('file-loader'),
+            loader: require.resolve('url-loader'),
         }],
     },
     resolve: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-devdep",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Common development dependencies for pc-nrfconnect-* packages.",
   "repository": {
     "type": "git",
@@ -51,6 +51,7 @@
     "semver": "5.3.0",
     "shasum": "1.0.2",
     "style-loader": "0.17.0",
+    "url-loader": "1.1.2",
     "webpack": "2.5.1"
   }
 }


### PR DESCRIPTION
Loading resources in apps doesn't work as expected since the app is already _required_ by core, thus URLs are relative to core's dist and not app's dist. `url-loader` seems to fix this issue, for now this is OK for small resources.